### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.3.2-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19

--- a/src/main/java/io/kestra/plugin/solace/Consume.java
+++ b/src/main/java/io/kestra/plugin/solace/Consume.java
@@ -15,6 +15,7 @@ import com.solace.messaging.MessagingService;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -32,7 +33,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 /**
  * The {@link RunnableTask} can be used for consuming messages from Solace.

--- a/src/main/java/io/kestra/plugin/solace/Produce.java
+++ b/src/main/java/io/kestra/plugin/solace/Produce.java
@@ -1,8 +1,6 @@
 package io.kestra.plugin.solace;
 
-import java.io.BufferedReader;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -13,6 +11,7 @@ import com.solace.messaging.resources.Topic;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Data;
 import io.kestra.core.models.property.Property;
@@ -36,7 +35,6 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
-import io.kestra.core.models.annotations.PluginProperty;
 
 /**
  * The {@link RunnableTask} can be used for producing messages to a Solace Broker.
@@ -169,30 +167,28 @@ public class Produce extends AbstractSolaceTask implements RunnableTask<Produce.
             .orElseThrow()
             .create(runContext.render(getMessageSerializerProperties()).asMap(String.class, Object.class));
 
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
-            final Topic topic = Topic.of(runContext.render(topicDestination).as(String.class).orElseThrow());
+        final Topic topic = Topic.of(runContext.render(topicDestination).as(String.class).orElseThrow());
 
-            AbstractSolaceDirectMessagePublisher sender = switch (runContext.render(deliveryMode).as(DeliveryModes.class).orElseThrow()) {
-                case DIRECT -> new SolaceDirectMessagePublisher(topic, serde, runContext.logger());
-                case PERSISTENT -> new SolacePersistentMessagePublisher(
-                    topic,
-                    serde,
-                    runContext.logger(),
-                    runContext.render(awaitAcknowledgementTimeout).as(Duration.class).orElseThrow()
-                );
-            };
-
-            MessagingService service = MessagingServiceFactory.create(this, runContext);
-            AbstractSolaceDirectMessagePublisher.SendResult result = sender.send(
-                reader,
-                service,
-                runContext.render(messageProperties).asMap(String.class, Object.class)
+        AbstractSolaceDirectMessagePublisher sender = switch (runContext.render(deliveryMode).as(DeliveryModes.class).orElseThrow()) {
+            case DIRECT -> new SolaceDirectMessagePublisher(topic, serde, runContext.logger());
+            case PERSISTENT -> new SolacePersistentMessagePublisher(
+                topic,
+                serde,
+                runContext.logger(),
+                runContext.render(awaitAcknowledgementTimeout).as(Duration.class).orElseThrow()
             );
+        };
 
-            runContext.metric(Counter.of("messages", result.totalSentMessages()));
+        MessagingService service = MessagingServiceFactory.create(this, runContext);
+        AbstractSolaceDirectMessagePublisher.SendResult result = sender.send(
+            stream,
+            service,
+            runContext.render(messageProperties).asMap(String.class, Object.class)
+        );
 
-            return new Output(result.totalSentMessages());
-        }
+        runContext.metric(Counter.of("messages", result.totalSentMessages()));
+
+        return new Output(result.totalSentMessages());
     }
 
     @AllArgsConstructor

--- a/src/main/java/io/kestra/plugin/solace/SolaceConnectionInterface.java
+++ b/src/main/java/io/kestra/plugin/solace/SolaceConnectionInterface.java
@@ -3,11 +3,11 @@ package io.kestra.plugin.solace;
 import java.util.Map;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import io.kestra.core.models.annotations.PluginProperty;
 
 public interface SolaceConnectionInterface {
 

--- a/src/main/java/io/kestra/plugin/solace/SolaceConsumeInterface.java
+++ b/src/main/java/io/kestra/plugin/solace/SolaceConsumeInterface.java
@@ -3,13 +3,13 @@ package io.kestra.plugin.solace;
 import java.time.Duration;
 import java.util.Map;
 
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.plugin.solace.serde.Serdes;
 import io.kestra.plugin.solace.service.receiver.QueueTypes;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import io.kestra.core.models.annotations.PluginProperty;
 
 public interface SolaceConsumeInterface extends SolaceConnectionInterface {
 

--- a/src/main/java/io/kestra/plugin/solace/Trigger.java
+++ b/src/main/java/io/kestra/plugin/solace/Trigger.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.executions.ExecutionTrigger;
@@ -27,7 +28,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 /**
  * The {@link Trigger} can be used for triggering flow based on messages received from Solace.

--- a/src/main/java/io/kestra/plugin/solace/service/publisher/AbstractSolaceDirectMessagePublisher.java
+++ b/src/main/java/io/kestra/plugin/solace/service/publisher/AbstractSolaceDirectMessagePublisher.java
@@ -1,6 +1,6 @@
 package io.kestra.plugin.solace.service.publisher;
 
-import java.io.BufferedReader;
+import java.io.InputStream;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
@@ -42,21 +42,21 @@ public abstract class AbstractSolaceDirectMessagePublisher {
     }
 
     /**
-     * Publishes all messages from the given reader.
+     * Publishes all messages from the given input stream.
      *
-     * @param reader The reader used to retrieve messages to be sent.
+     * @param inputStream The input stream used to retrieve messages to be sent.
      * @param messagingService The {@link MessagingService} used to build a new {@link DirectMessagePublisher}.
      * @param additionalMessageProperties The additional message properties to customize all messages to b published.
      * @return a new {@link SendResult}.
      */
-    public SendResult send(BufferedReader reader,
+    public SendResult send(InputStream inputStream,
         MessagingService messagingService,
         Map<String, String> additionalMessageProperties) {
 
         MessagePublisher publisher = open(messagingService);
         logger.debug("Connected to Solace instance name {}", publisher.publisherInfo().getInstanceName());
         try {
-            Flux<OutboundMessageObject> flowable = FileSerde.readAll(reader, OutboundMessageObject.class);
+            Flux<OutboundMessageObject> flowable = FileSerde.readAll(inputStream, OutboundMessageObject.class);
             final Integer numSentMessages = flowable
                 .map(throwFunction(outboundMessageObject ->
                 {

--- a/src/test/java/io/kestra/plugin/solace/ConsumeTest.java
+++ b/src/test/java/io/kestra/plugin/solace/ConsumeTest.java
@@ -1,9 +1,13 @@
 package io.kestra.plugin.solace;
 
-import java.io.BufferedReader;
-import java.io.StringReader;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -18,6 +22,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.FileSerde;
 import io.kestra.plugin.solace.client.MessagingServiceFactory;
 import io.kestra.plugin.solace.serde.Serdes;
 import io.kestra.plugin.solace.service.publisher.SolacePersistentMessagePublisher;
@@ -52,9 +57,9 @@ class ConsumeTest extends BaseSolaceIT {
             .queueType(Property.ofValue(QueueTypes.DURABLE_EXCLUSIVE))
             .build();
 
-        try (BufferedReader message = new BufferedReader(new StringReader("""
+        try (InputStream message = new ByteArrayInputStream("""
             {"payload": "test-message"}
-            """))) {
+            """.getBytes(StandardCharsets.UTF_8))) {
             MessagingService service = MessagingServiceFactory.create(task, runContext);
             SolacePersistentMessagePublisher publisher = new SolacePersistentMessagePublisher(
                 Topic.of("topic"),
@@ -71,5 +76,12 @@ class ConsumeTest extends BaseSolaceIT {
 
         // Then
         Assertions.assertEquals(1, runOutput.getMessagesCount());
+
+        // Verify ION read-back from storage
+        try (InputStream is = new BufferedInputStream(runContext.storage().getFile(runOutput.getUri()), FileSerde.BUFFER_SIZE)) {
+            List<Object> result = new ArrayList<>();
+            FileSerde.read(is, result::add);
+            Assertions.assertEquals(1, result.size());
+        }
     }
 }

--- a/src/test/java/io/kestra/plugin/solace/TriggerTest.java
+++ b/src/test/java/io/kestra/plugin/solace/TriggerTest.java
@@ -18,6 +18,7 @@ import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.LocalFlowRepositoryLoader;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.TestsUtils;
+
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import reactor.core.publisher.Flux;
@@ -44,7 +45,8 @@ class TriggerTest extends BaseSolaceIT {
     @Test
     void testTriggerTask() throws Exception {
         CountDownLatch queueCount = new CountDownLatch(1);
-        Flux<Execution> receive = TestsUtils.receive(executionQueue, execution -> {
+        Flux<Execution> receive = TestsUtils.receive(executionQueue, execution ->
+        {
             queueCount.countDown();
             assertThat(execution.getLeft().getFlowId(), is("trigger"));
         });


### PR DESCRIPTION
## Summary
- Bump `kestraVersion` to `1.3.19`
- Replace deprecated `BufferedReader`/`InputStreamReader`-based `FileSerde.readAll(reader, ...)` with `InputStream`-based `FileSerde.readAll(inputStream, ...)` for binary ION compatibility
- Update `AbstractSolaceDirectMessagePublisher.send()` signature from `BufferedReader` to `InputStream`
- Update test in `ConsumeTest` to use `ByteArrayInputStream` instead of `BufferedReader`/`StringReader`

Ref: kestra-io/kestra#3155